### PR TITLE
Wrong type of GeoJSON

### DIFF
--- a/OGPD_JSON_Schema.json
+++ b/OGPD_JSON_Schema.json
@@ -248,7 +248,7 @@
             "type": {
               "type": "string",
               "description": "Art der Form: Hier ist zunächst nur Polygon vorgesehen, andere waeren vorstellbar.",
-              "enum": ["polygon"]
+              "enum": ["Polygon"]
             }, 
             "coordinates": {
               "type": "array",


### PR DESCRIPTION
I think the entry

 "spatial": {
         ...
          "properties": {
            "type": {
             ...
              "enum": ["polygon"]
            }

is wrong.


Have a look at
http://geojson.org/geojson-spec.html#id4


It's correct to write the "P" of "polygon" in upper case.


Applications like http://geojson.io doesn't accept GeoJSON with the type "polygon" in lower case.